### PR TITLE
Actualizar referencias luego de renombrar repo a katupyry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ And its completely open-source.
 
 ## How to use
 
-Click on the [Use Template](https://github.com/surjithctly/nextly-template/generate) button on this page to clone this respository to your github account. Or you can also clone this respository using terminal or bash. 
+Click on the [Use Template](https://github.com/mgaitan/katupyry/generate) button on this page to clone this respository to your github account. Or you can also clone this respository using terminal or bash. 
 
 ### 1\. Clone this Repository
 
 ```bash
-git clone https://github.com/surjithctly/nextly-template.git
+git clone https://github.com/mgaitan/katupyry.git
 ```
 
 ### 2\. Navigate to the directory
 
 ```
-cd nextly-template
+cd katupyry
 ```
 
 ### 3\. Install dependencies
@@ -50,7 +50,7 @@ npm run dev
 
 Deploy this template using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/mgaitan/nextly-template&project-name=nextly-template&repository-name=nextly-template)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/mgaitan/katupyry&project-name=katupyry&repository-name=katupyry)
 
 
 ## Author

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextly-template",
+  "name": "katupyry",
   "version": "2.0.0",
   "description": "Nextly Landing Page Template",
   "private": true,
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/web3templates/nextly-template"
+    "url": "https://github.com/mgaitan/katupyry"
   },
   "keywords": [
     "nextjs",


### PR DESCRIPTION
Closes #3

- Repo renombrado en GitHub de nextly-template a katupyry.
- Remote local origin actualizado a git@github.com:mgaitan/katupyry.git.
- Referencias en package.json y README ajustadas al nombre nuevo.
